### PR TITLE
Updated pin mapping with correct pinouts

### DIFF
--- a/src/app/starduino-zumo/README.md
+++ b/src/app/starduino-zumo/README.md
@@ -1,13 +1,13 @@
 # Pinout
 
-STM8 Pin | Starduino Pin | Zumo Pin | Peripheral | Function | Notes
---- | --- | --- | --- | --- | ---
-PE1 | SCL | SCL | I2C SCL | I2C SCL |
-PE2 | SDA | SDA | I2C SDA | I2C SDA |
-PC5 | 13 | 13 | GPIO | Heartbeat LED |
-PC6 | 11 | 8 | GPIO | Left motor direction |
-PC7 | 12 | 7 | GPIO | Right motor direction |
-PD3 | 5 | 10 | TIM2_CH2 | Left motor power |
-PD4 | 3 | 9 | TIM2_CH1 | Right motor power |
-PC1 | 4 | 4 | TIM1_CH1 | Left line sensor |
-PC2 | 9 | 5 | TIM1_CH2 | Right line sensor |
+| STM8 Pin | Starduino / Zumo Pin | Peripheral | Function              | Notes |
+| -------- | -------------------- | ---------- | --------------------- | ----- |
+| PE1      | SCL                  | I2C SCL    | I2C SCL               |
+| PE2      | SDA                  | I2C SDA    | I2C SDA               |
+| PC5      | 13                   | GPIO       | Heartbeat LED         |
+| PD0      | 8                    | GPIO       | Left motor direction  |
+| PB6      | 7                    | GPIO       | Right motor direction |
+| PE5      | 10                   | TIM2_CH2   | Left motor power      |
+| PC2      | 9                    | TIM2_CH1   | Right motor power     |
+| PC1      | 4                    | TIM1_CH1   | Left line sensor      |
+| PD3      | 5                    | TIM1_CH2   | Right line sensor     |

--- a/src/app/starduino-zumo/README.md
+++ b/src/app/starduino-zumo/README.md
@@ -7,7 +7,7 @@
 | PC5      | 13                   | GPIO       | Heartbeat LED         |
 | PD0      | 8                    | GPIO       | Left motor direction  |
 | PB6      | 7                    | GPIO       | Right motor direction |
-| PE5      | 10                   | TIM2_CH2   | Left motor power      |
-| PC2      | 9                    | TIM2_CH1   | Right motor power     |
+| PE5      | 10                   |            | Left motor power      |
+| PC2      | 9                    | TIM1_CH2   | Right motor power     |
 | PC1      | 4                    | TIM1_CH1   | Left line sensor      |
-| PD3      | 5                    | TIM1_CH2   | Right line sensor     |
+| PD3      | 5                    | TIM2_CH2   | Right line sensor     |


### PR DESCRIPTION
The Starduino pinout is the same as the Zumo shield, so there was no need to translate between the two.

I'll start on some of the actual changes later today.

Not sure why vscode decided to reformat the file, but I didn't feel like trying to "correct" it