### PR TITLE
Added starduino heartbeat

### DIFF
--- a/src/app/starduino-zumo/README.md
+++ b/src/app/starduino-zumo/README.md
@@ -1,10 +1,11 @@
 # Pinout
 
 | STM8 Pin | Zumo Pin | Peripheral | Function              |
-|----------|----------|------------|-----------------------|
+| -------- | -------- | ---------- | --------------------- |
+| PA3      | N/A      | GPIO       | Heartbeat LED         |
 | PE1      | SCL      | I2C SCL    | I2C SCL               |
 | PE2      | SDA      | I2C SDA    | I2C SDA               |
-| PC2      | 13       | GPIO       | Heartbeat LED         |
+| PC2      | 13       | GPIO       | Zumo Heartbeat LED    |
 | PD0      | 8        | GPIO       | Left motor direction  |
 | PE3      | 7        | GPIO       | Right motor direction |
 | PD3      | 10       | TIM2_CH2   | Left motor power      |

--- a/src/app/starduino-zumo/main.c
+++ b/src/app/starduino-zumo/main.c
@@ -8,7 +8,7 @@
 #include "stm8s.h"
 #include "clock.h"
 #include "tim4_system_tick.h"
-#include "pc5_heartbeat.h"
+#include "pa3_heartbeat.h"
 #include "tiny_timer.h"
 #include "watchdog.h"
 #include "data_model.h"
@@ -30,7 +30,7 @@ void main(void) {
     watchdog_init();
     clock_init();
     tiny_timer_group_init(&timer_group, tim4_system_tick_init());
-    pc5_heartbeat_init(&timer_group);
+    pa3_heartbeat_init(&timer_group);
     application_init(&application, &timer_group);
   }
   enableInterrupts();

--- a/src/app/starduino-zumo/main.c
+++ b/src/app/starduino-zumo/main.c
@@ -9,6 +9,7 @@
 #include "clock.h"
 #include "tim4_system_tick.h"
 #include "pa3_heartbeat.h"
+#include "pc5_heartbeat.h"
 #include "tiny_timer.h"
 #include "watchdog.h"
 #include "data_model.h"
@@ -31,6 +32,7 @@ void main(void) {
     clock_init();
     tiny_timer_group_init(&timer_group, tim4_system_tick_init());
     pa3_heartbeat_init(&timer_group);
+    pc5_heartbeat_init(&timer_group);
     application_init(&application, &timer_group);
   }
   enableInterrupts();

--- a/starduino-zumo.mk
+++ b/starduino-zumo.mk
@@ -18,6 +18,7 @@ LIB_FILES := \
   src/peripheral/clock.c \
   src/peripheral/i2c.c \
   src/peripheral/pa3_heartbeat.c \
+  src/peripheral/pc5_heartbeat.c \
   src/peripheral/tim4_system_tick.c \
   src/peripheral/watchdog.c \
 

--- a/starduino-zumo.mk
+++ b/starduino-zumo.mk
@@ -17,7 +17,7 @@ LIB_FILES := \
   src/peripheral/adc2.c \
   src/peripheral/clock.c \
   src/peripheral/i2c.c \
-  src/peripheral/pc5_heartbeat.c \
+  src/peripheral/pa3_heartbeat.c \
   src/peripheral/tim4_system_tick.c \
   src/peripheral/watchdog.c \
 


### PR DESCRIPTION
PA3 is the heartbeat for the starduino board itself.
PC5 is for the Zumo board.